### PR TITLE
Setup testing skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.pyc
+
 docs/_build
 
 .venv

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+sudo: required
+
+language: python
+cache: pip
+
+python:
+  - '2.7'
+
+services:
+  - docker
+
+install:
+  - pip install -r requirements.txt
+  - python setup.py develop
+
+script:
+  - make lint
+  - make unit_tests
+  - make integration_tests

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+lint:
+	pylint ./sheepdog
+
+unit_tests:
+	nose2 -s tests/unit
+
+integration_tests:
+	./tests/integration/run_integration_tests.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
+mock==2.0.0
+nose2<=1.0
+pylint>=1.0,<2.0
 sphinx>=1.0,<2.0
 sphinx-autobuild<=1.0

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+"""Configuration for the `sheepdog` pip package."""
+
+from setuptools import setup
+
+GITHUB_URL = 'https://github.com/mattjmcnaughton/sheepdog'
+
+# @TODO(mattjmcnaughton) determine this value dynamically.
+VERSION = '0.1.0'
+
+setup(
+    name='sheepdog',
+    version=VERSION,
+    description='Manage your personal Unix machine(s) with Ansible.',
+    author='Matt McNaughton',
+    license='Apache',
+    author_email='mattjmcnaughton@gmail.com',
+    url=GITHUB_URL,
+    download_url='{}/tarball/{}'.format(GITHUB_URL, VERSION),
+    keywords=['provisioning', 'automation'],
+    install_requires=[],
+    packages=['sheepdog'],
+    entry_points={
+        'console_scripts': ['sheepdog = sheepdog.cli:main']
+    }
+)

--- a/sheepdog/__init__.py
+++ b/sheepdog/__init__.py
@@ -1,0 +1,5 @@
+"""Base sheepdog module. Sets version and what is accessible through
+`sheepdog.`
+"""
+
+from .cli import cli

--- a/sheepdog/cli.py
+++ b/sheepdog/cli.py
@@ -1,0 +1,9 @@
+"""The point of entry for the sheepdog pip package console script"""
+
+def cli():
+    """Creates the command line interface for interacting with sheepdog."""
+    print 'Sheepdog'
+
+def main():
+    """The entry point for running `sheepdog`."""
+    cli()

--- a/sheepdog_runner.py
+++ b/sheepdog_runner.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+"""
+A helper script for executing `sheepdog` directly from source.
+"""
+
+from sheepdog.cli import main
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/run_integration_tests.sh
+++ b/tests/integration/run_integration_tests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Create docker image from docker file which runs pup/kennel
+# Ensure docker image has expected state
+
+# Other integration tests could involve using `sheepdog_runner.py`?
+
+echo 'hi'

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,5 @@
+import unittest
+
+class CliTestCase(unittest.TestCase):
+    def test_true(self):
+        self.assertTrue(True)


### PR DESCRIPTION
Fix #4 

Determine the layout for the unit and e2e tests. These tests have not
actually been written yet, but creating the scaffolding lets us get
travis running.

We use two types of tests. Unit tests which test the individual
components of `sheepdog` and integration tests, which test using sample
pups/kennels to configure a blank Docker image. Travis will run both.