### PR TITLE
Add travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # sheepdog
 
+[![Build
+Status](https://travis-ci.org/mattjmcnaughton/sheepdog.svg?branch=master)](https://travis-ci.org/mattjmcnaughton/sheepdog)
+
 Manage your personal Unix machine(s) with [Ansible](https://www.ansible.com/)
 (aka [boxen](https://github.com/boxen/boxen) but for Ansible).
 


### PR DESCRIPTION
A small commit, responsible mainly for adding the travis badge. Creating
on a separate branch so I can check travis successfully builds pull
requests.