### PR TITLE
Run e2e test using docker, sheepdog, and samples

### DIFF
--- a/tests/integration/kennels/kennel-trivial-sample/README.md
+++ b/tests/integration/kennels/kennel-trivial-sample/README.md
@@ -1,0 +1,4 @@
+# kennel-trivial-sample
+
+The simplest possible kennel. Responsible for including `pup-trivial-sample`,
+and that's it.

--- a/tests/integration/pups/pup-trivial-sample/README.md
+++ b/tests/integration/pups/pup-trivial-sample/README.md
@@ -1,0 +1,7 @@
+# pup-trivial-sample
+
+A simple pup for integration testing. It writes an encrypted secret, and
+unencrypted variable, and a default value to `~/.pup-trivial-sample-output`.
+
+The integration test asserts correctness by checking the sample file exists with
+the proper values.

--- a/tests/integration/run_integration_tests.sh
+++ b/tests/integration/run_integration_tests.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
+#
+# Run all sheepdog integration tests. Sheepdog has a number of different
+# integration tests, each one representing a different main feature through an
+# example.
 
-# Create docker image from docker file which runs pup/kennel
-# Ensure docker image has expected state
+set -e
 
-# Other integration tests could involve using `sheepdog_runner.py`?
+SD=$(dirname $0)
 
-echo 'hi'
+cd $SD/tests/trivial; /bin/bash ./run_test.sh;

--- a/tests/integration/tests/trivial/Dockerfile
+++ b/tests/integration/tests/trivial/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:2.7
+
+ADD tmp_scratch /test
+ADD run_sheepdog.sh /test/run_sheepdog.sh
+ADD assert_e2e_state.sh /test/assert_e2e_state.sh
+
+WORKDIR /test
+
+RUN chmod u+x /test/*.sh
+
+RUN pip install --upgrade pip
+RUN pip install -r requirements.txt
+RUN python setup.py develop

--- a/tests/integration/tests/trivial/README.md
+++ b/tests/integration/tests/trivial/README.md
@@ -1,0 +1,5 @@
+# trivial
+
+The simplest possible e2e test that does anything interesting.
+Use the `kennel-trivial`, which includes only `pup-sample-trivial`. Assert
+`pup-sample-trivial` creates the expected files.

--- a/tests/integration/tests/trivial/assert_e2e_state.sh
+++ b/tests/integration/tests/trivial/assert_e2e_state.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Note, this script should be run in the docker container.
+
+# Check sheepdog enacted the proper state on the docker container.
+
+exit 0

--- a/tests/integration/tests/trivial/run_sheepdog.sh
+++ b/tests/integration/tests/trivial/run_sheepdog.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# Provision the docker container with sheepdog.
+
+DIR=/test
+
+# @TODO(mattjmcnaughton) This should run `sheepdog install` and `sheepdog run`
+# with the proper kennel file.
+cd $DIR; ./sheepdog_runner.py

--- a/tests/integration/tests/trivial/run_test.sh
+++ b/tests/integration/tests/trivial/run_test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e
+
+IMAGE_NAME=sheepdog/test_trivial_image
+DIR=/test
+
+# Move the necessary files within the parent directory to this directory so that
+# we can access them in the Dockerfile.
+SD=$(dirname $0)
+TMP_SCRATCH="$SD/tmp_scratch"
+mkdir $TMP_SCRATCH
+
+teardown() {
+    rm -r $TMP_SCRATCH
+}
+
+trap 'teardown' EXIT
+
+mkdir "$TMP_SCRATCH/kennels"
+cp -r "$SD/../../kennels/kennel-trivial-sample" "$TMP_SCRATCH/kennels/kennel-trivial-sample"
+
+mkdir "$TMP_SCRATCH/pups"
+cp -r "$SD/../../pups/pup-trivial-sample" "$TMP_SCRATCH/pups/pup-trivial-sample"
+cp "$SD/../../../../sheepdog_runner.py" "$TMP_SCRATCH/"
+cp "$SD/../../../../requirements.txt" "$TMP_SCRATCH/"
+cp "$SD/../../../../setup.py" "$TMP_SCRATCH/"
+cp -r "$SD/../../../../sheepdog" "$TMP_SCRATCH/sheepdog"
+
+# Bring up a blank docker image, with the kennel and pup.
+docker build -t $IMAGE_NAME .
+
+docker run $IMAGE_NAME /bin/bash -c "$DIR/run_sheepdog.sh && $DIR/assert_e2e_state.sh"


### PR DESCRIPTION
Add skeleton for first integration test using Docker, sheepdog, and
sample pups and kennels. We provision the docker container to a certain
state by running a kennel with the current version of sheepdog. We then
run a script that asserts the container is in the proper state.