### PR TITLE
Refactor `Config` class as singleton

### DIFF
--- a/sheepdog/action/__init__.py
+++ b/sheepdog/action/__init__.py
@@ -1,13 +1,16 @@
 """Top-level module for sheepdog actions"""
 
+from sheepdog.config import Config
+
+
 class Action(object):
     """A base class for all actions.
 
     :param config: The configuration object for performing this action.
     :type config: sheepdog.config.Config
     """
-    def __init__(self, config):
-        self._config = config
+    def __init__(self, config=None):
+        self._config = config or Config.get_config_singleton()
 
     def run(self):
         """Execute this action."""

--- a/sheepdog/action/install.py
+++ b/sheepdog/action/install.py
@@ -1,30 +1,21 @@
 """Module for code relating to installing pups for a kennel."""
 
-from collections import namedtuple
-
 from sheepdog.action import Action
 from sheepdog.kennel import Kennel
 from sheepdog.pup import Pup
-
-InstallDirectories = namedtuple('InstallDirectories', 'pupfile_dir kennel_roles_dir')
 
 
 class InstallAction(Action):
     def __init__(self, *args, **kwargs):
         super(InstallAction, self).__init__(*args, **kwargs)
 
-        self._install_dirs = InstallDirectories(
-            pupfile_dir=self._config.get('abs_pupfile_dir'),
-            kennel_roles_dir=self._config.get('abs_kennel_roles_dir')
-        )
-
-        self._pups_to_install = None
+        self._pups_to_install = []
 
     def _setup(self):
-        Kennel.refresh_roles(self._install_dirs.kennel_roles_dir)
+        Kennel.refresh_roles(self._config.get('abs_kennel_roles_dir'))
         self._pups_to_install = Pup.parse_pupfile_into_pups(
             self._config.get('pupfile_path'))
 
     def _execute(self):
         for pup in self._pups_to_install:
-            pup.install(self._install_dirs)
+            pup.install()

--- a/sheepdog/action/run.py
+++ b/sheepdog/action/run.py
@@ -16,11 +16,7 @@ class RunAction(Action):
         self._kennel = None
 
     def _setup(self):
-        self._kennel = Kennel.parse_kennel_from_config_files(
-            self._config.get('kennel_playbook_path'),
-            self._config.get('kennel_roles_path'),
-            self._config.get('kennel_cfg_path'),
-        )
+        self._kennel = Kennel()
 
     def _execute(self):
         try:

--- a/sheepdog/app.py
+++ b/sheepdog/app.py
@@ -1,5 +1,8 @@
 """Orchestrates the different `sheepdog` operations."""
 
+from sheepdog.config import Config
+
+
 class Sheepdog(object):
     """A class we instantiate with instances of the `Action`, which indicate
     which cli command we'll perform.
@@ -7,8 +10,9 @@ class Sheepdog(object):
     :param action: The Sheepdog action we're running.
     :type action: sheepdog.action.Action
     """
-    def __init__(self, action):
+    def __init__(self, action, config=None):
         self._action = action
+        self._config = config or Config.get_config_singleton()
 
     def run(self):
         """Execute an command given to `sheepdog`."""

--- a/sheepdog/cli.py
+++ b/sheepdog/cli.py
@@ -14,18 +14,21 @@ ACTIONS = {
 
 @click.command()
 @click.argument('action', type=click.Choice(ACTIONS.keys()))
-@click.option('--config-file')
+@click.option('--config-file', default='kennel.cfg')
 def cli(action, config_file):
     """CLI for sheepdog interactions.
 
     :param action: Which cli action we wish to take.
     :type action: str
-    :param config_file: Path to `sheepdog.cfg`. If not specified, use
+    :param config_file: Path to kennel configuration. If not specified, use
     `./kennel.cfg`
     :type config_file: str
     """
-    config = Config(config_file)
-    action = ACTIONS[action](config)
+    with open(config_file, 'r') as config_file_open_for_reading:
+        config_file_contents = config_file_open_for_reading.read()
+
+    Config.initialize_config_singleton(config_file_contents)
+    action = ACTIONS[action]()
 
     sheepdog = Sheepdog(action)
     sheepdog.run()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,30 +1,60 @@
-import os
 import unittest
 
-from sheepdog.config import DEFAULTS, Config
+from sheepdog.config import (Config, DEFAULTS,
+                             SheepdogConfigurationAlreadyInitializedException,
+                             SheepdogConfigurationNotInitializedException)
 
 
 class ConfigTestCase(unittest.TestCase):
     def setUp(self, *args, **kwargs):
         super(ConfigTestCase, self).setUp(*args, **kwargs)
 
-        self._only_default_config = Config()
+        Config.clear_config_singleton()
 
-    def test_config_hierarchy_default_final_option(self):
-        """Test if we specify no additional config, we'll return all default
-        values.
-        """
-        for field, default_value in DEFAULTS.iteritems():
-            self.assertEqual(self._only_default_config.get(field),
-                             default_value)
+    def test_must_initialize_config_before_using(self):
+        with self.assertRaises(SheepdogConfigurationNotInitializedException):
+            Config.get_config_singleton()
 
-    def test_calculated_configurations(self):
-        """Test the configurations we calculate on the fly based on other
-        configuration values.
-        """
-        current_directory = os.path.realpath('.')
+    def test_can_only_initialize_config_once(self):
+        Config.initialize_config_singleton()
 
-        self.assertEqual(self._only_default_config.get('abs_pupfile_dir'),
-                         current_directory)
-        self.assertEqual(self._only_default_config.get('abs_kennel_roles_dir'),
-                         os.path.join(current_directory, DEFAULTS['kennel_roles_path']))
+        with self.assertRaises(SheepdogConfigurationAlreadyInitializedException):
+            Config.initialize_config_singleton()
+
+    def test_initialize_config_with_defaults(self):
+        Config.initialize_config_singleton()
+        config = Config.get_config_singleton()
+
+        for default_key, default_value in DEFAULTS.iteritems():
+            self.assertEqual(config.get(default_key), default_value)
+
+    def test_initialize_config_with_config_file_values(self):
+        config_file_pupfile_path = 'config_pupfile.yml'
+        config_file_contents = """
+        [kennel]
+        pupfile_path={}
+        """.format(config_file_pupfile_path)
+
+        Config.initialize_config_singleton(config_file_contents=config_file_contents)
+        config = Config.get_config_singleton()
+
+        self.assertEqual(config.get('pupfile_path'), config_file_pupfile_path)
+
+    def test_initialize_config_with_config_option_values(self):
+        config_options_pupfile_path = 'config_pupfile.yml'
+
+        config_options = {
+            'pupfile_path': config_options_pupfile_path
+        }
+
+        Config.initialize_config_singleton(config_options=config_options)
+        config = Config.get_config_singleton()
+
+        self.assertEqual(config.get('pupfile_path'), config_options_pupfile_path)
+
+    def test_initialize_config_with_calculated_config(self):
+        Config.initialize_config_singleton()
+        config = Config.get_config_singleton()
+
+        for key in {'abs_pupfile_dir', 'abs_kennel_roles_dir'}:
+            self.assertIn('/', config.get(key))

--- a/tests/unit/test_kennel.py
+++ b/tests/unit/test_kennel.py
@@ -3,10 +3,17 @@ import os
 import tempfile
 import unittest
 
+from sheepdog.config import Config
 from sheepdog.kennel import Kennel
 
 
 class KennelTestCase(unittest.TestCase):
+    def setUp(self, *args, **kwargs):
+        super(KennelTestCase, self).setUp(*args, **kwargs)
+
+        Config.clear_config_singleton()
+        Config.initialize_config_singleton()
+
     def test_refresh_roles_dir_exists(self):
         """Test `refresh_roles` properly refreshes the kennel roles path
         when the kennel roles dir already exists."""
@@ -24,15 +31,7 @@ class KennelTestCase(unittest.TestCase):
         arguments to `subprocess.check_call`. We rely on the integration
         tests for checking the playbook ran successfully.
         """
-        mock_kennel_playbook_path = 'mock_kennel.yml'
-        mock_kennel_roles_path = '.mock_kennel_roles'
-        mock_kennel_config = {
-            'vault_password_file': 'mock_vault_password_file'
-        }
-
-        kennel = Kennel(mock_kennel_playbook_path, mock_kennel_roles_path,
-                        mock_kennel_config)
-
+        kennel = Kennel()
         kennel.run()
 
         self.assertEqual(mock_check_call.call_count, 1)
@@ -41,8 +40,8 @@ class KennelTestCase(unittest.TestCase):
         ansible_playbook_cmd = check_call_args[0]
 
         for expected_arg in {'ansible-playbook',
-                             'mock_kennel.yml',
-                             '--vault-password-file=mock_vault_password_file'}:
+                             'kennel.yml',
+                             '--vault-password-file'}:
             self.assertIn(expected_arg, ansible_playbook_cmd)
 
         self.assertTrue(check_call_kwargs['shell'])


### PR DESCRIPTION
The previous role of the `Config` class was not clearly defined. It was
responsible for managing configuration, but only some classes could
access it. This lack of accessibility meant methods often had a number
of parameters, and we often had to pass parameters through multiple
methods before they arose at the method which actually used them.

Instead, we implement the singleton pattern, so we initialize the
configuration once with default/runtime values, and then allow multiple
consumers to read from it. Additionally, we allow class constructors to
either accept instances of `Config` as an argument or to get the current
singleton. This grants us flexibility during testing.