### PR TITLE
Sync kennel with git before cron run

### DIFF
--- a/tests/integration/kennels/kennel-update-kennel-before-cron-sample/README.md
+++ b/tests/integration/kennels/kennel-update-kennel-before-cron-sample/README.md
@@ -1,0 +1,7 @@
+# kennel-update-kennel-before-cron
+
+The kennel testing the functionality where we run pull the most recent version
+of the kennel from git and run `sheepdog install` before the cron run.
+
+Hosted remotely at
+https://github.com/mattjmcnaughton/kennel-update-kennel-before-cron.

--- a/tests/integration/pups/pup-base/tasks/setup_cron.yml
+++ b/tests/integration/pups/pup-base/tasks/setup_cron.yml
@@ -21,6 +21,18 @@
 - set_fact:
     use_bashrc: "{{ sheepdog_use_bashrc_for_cron | bool }}"
 
+- name: Check if the kennel is version controlled through git.
+  command: git -C "{{ playbook_dir }}" rev-parse
+  register: git_check_result
+  ignore_errors: True
+
+- set_fact:
+    git_update_cmd: "echo 'Git repo not found in {{ playbook_dir }}'"
+
+- set_fact:
+    git_update_cmd: "git pull origin master"
+  when: git_check_result|succeeded
+
 - name: Run sheepdog with virtualenv.
   cron:
     name: Run sheepdog cron.
@@ -29,7 +41,8 @@
     job: >
       source {{ sheepdog_virtualenv_path }}/bin/activate &&
       cd "{{ playbook_dir }}" &&
-      bash -c "sheepdog run --run-mode cron" >>
+      {{ git_update_cmd }} &&
+      bash -c "sheepdog install && sheepdog run --run-mode cron" >>
       {{ sheepdog_cron_log_path }} 2>&1
   when: use_virtualenv and not use_bashrc
   notify: restart cron
@@ -41,7 +54,8 @@
     hour: "{{ sheepdog_cron_interval_hours }}"
     job: >
       cd "{{ playbook_dir }}" &&
-      bash -c ". ~/.bashrc && sheepdog run --run-mode cron" >>
+      {{ git_update_cmd }} &&
+      bash -c ". ~/.bashrc && sheepdog install && sheepdog run --run-mode cron" >>
       {{ sheepdog_cron_log_path }} 2>&1
   when: use_bashrc and not use_virtualenv
   notify: restart cron
@@ -53,7 +67,8 @@
     hour: "{{ sheepdog_cron_interval_hours }}"
     job: >
       cd "{{ playbook_dir }}" &&
-      bash -c "sheepdog run --run-mode cron" >>
+      {{ git_update_cmd }} &&
+      bash -c "sheepdog install && sheepdog run --run-mode cron" >>
       {{ sheepdog_cron_log_path }} 2>&1
   when: not use_virtualenv and not use_bashrc
   notify: restart cron

--- a/tests/integration/run_integration_tests.sh
+++ b/tests/integration/run_integration_tests.sh
@@ -26,3 +26,4 @@ cd $SD/tests/trivial; /bin/bash ./run_test.sh $INTERACTIVE_FLAG;
 cd $SD/tests/cron-bootstrap; /bin/bash ./run_test.sh $INTERACTIVE_FLAG;
 cd $SD/tests/dependencies; /bin/bash ./run_test.sh $INTERACTIVE_FLAG;
 cd $SD/tests/external-pups; /bin/bash ./run_test.sh $INTERACTIVE_FLAG;
+cd $SD/tests/update-kennel-before-cron; /bin/bash ./run_test.sh $INTERACTIVE_FLAG;

--- a/tests/integration/tests/update-kennel-before-cron/Dockerfile
+++ b/tests/integration/tests/update-kennel-before-cron/Dockerfile
@@ -1,0 +1,35 @@
+FROM python:2.7
+
+RUN apt-get update && apt-get install -y git
+
+ADD tmp_scratch/requirements.txt /test/requirements.txt
+
+WORKDIR /test
+
+RUN pip install --upgrade pip
+# Because installing ansible is so expensive, we do it before any elements of
+# the Dockerfile which are likely to change. Docker will cache it.
+RUN pip install "ansible>=2.0,<3.0"
+RUN pip install -r requirements.txt
+
+ADD tmp_scratch /test
+ADD run_sheepdog.sh /test/run_sheepdog.sh
+ADD assert_e2e_state.sh /test/assert_e2e_state.sh
+
+RUN python setup.py develop
+
+RUN chmod u+x /test/*.sh
+
+# Add the setting which prefers the newly installed python to our system
+# to our `.bashrc` file, which we will then source before running the
+# sheepdog command.
+RUN echo "export PATH=/usr/local/bin:$PATH" > ~/.bashrc
+
+# Create an executable symlink to `sheepdog_runner.py` from `/usr/bin/sheepdog`.
+RUN ln -s /test/sheepdog_runner.py /usr/bin/sheepdog
+RUN chmod u+x /usr/bin/sheepdog
+
+RUN mkdir /test/kennels
+
+# Pull the most recent version of sheepdog from git
+RUN git clone https://github.com/mattjmcnaughton/kennel-update-kennel-before-cron.git /test/kennels/kennel-update-kennel-before-cron-sample

--- a/tests/integration/tests/update-kennel-before-cron/README.md
+++ b/tests/integration/tests/update-kennel-before-cron/README.md
@@ -1,0 +1,5 @@
+# update-kennel-before-cron
+
+An e2e test asserting our cron job running `sheepdog run --run-mode cron` first
+pulls the most recent copy of the kennel from the remote git url and runs
+`sheepdog install`.

--- a/tests/integration/tests/update-kennel-before-cron/assert_e2e_state.sh
+++ b/tests/integration/tests/update-kennel-before-cron/assert_e2e_state.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Note, this script should be run in the docker container.
+
+# Check sheepdog enacted the proper state on the docker container.
+# The cron role should have been run 3 times, the no-special-tag role should have
+# run 2 times, and the bootstrap role should have run 1 time.
+
+set -e
+
+# First argument is file, second is pattern, third is the min number of occurrences
+# of pattern we expect in file.
+assert_e2e_state::check_occurrences_in_file() {
+    matches=$(grep -s "$2" "$1" | wc -l)
+
+    if [ "$matches" -lt "$3" ]
+    then
+        echo "Failed $1, $2, $3" >&2
+        exit 1
+    fi
+}
+
+assert_e2e_state::check_occurrences_in_file ~/.pup-cron-output "encrypted_nightly_test" 3
+assert_e2e_state::check_occurrences_in_file ~/.pup-no-special-tag-output "unencrypted_var_test" 2
+assert_e2e_state::check_occurrences_in_file ~/.pup-bootstrap-output "encrypted_boot_test" 1
+
+exit 0

--- a/tests/integration/tests/update-kennel-before-cron/run_sheepdog.sh
+++ b/tests/integration/tests/update-kennel-before-cron/run_sheepdog.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Provision the docker container with sheepdog.
+
+DIR=/test/kennels/kennel-update-kennel-before-cron-sample
+
+cd $DIR;\
+sheepdog install &&\
+sheepdog run --run-mode bootstrap &&\
+sheepdog run &&\
+echo 'Waiting 120 seconds for cron job to execute' &&\
+sleep 120

--- a/tests/integration/tests/update-kennel-before-cron/run_test.sh
+++ b/tests/integration/tests/update-kennel-before-cron/run_test.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -e
+
+IMAGE_NAME=sheepdog/test_update_kennel_before_cron_image
+DIR=/test
+
+# Move the necessary files within the parent directory to this directory so that
+# we can access them in the Dockerfile.
+SD=$(dirname $0)
+TMP_SCRATCH="$SD/tmp_scratch"
+mkdir $TMP_SCRATCH
+
+teardown() {
+    rm -r $TMP_SCRATCH
+}
+
+trap 'teardown' EXIT
+
+mkdir "$TMP_SCRATCH/pups"
+cp -r "$SD/../../pups/pup-base" "$TMP_SCRATCH/pups/pup-base"
+cp -r "$SD/../../pups/pup-no-special-tag" "$TMP_SCRATCH/pups/pup-no-special-tag"
+cp -r "$SD/../../pups/pup-cron" "$TMP_SCRATCH/pups/pup-cron"
+cp -r "$SD/../../pups/pup-bootstrap" "$TMP_SCRATCH/pups/pup-bootstrap"
+cp "$SD/../../../../sheepdog_runner.py" "$TMP_SCRATCH/"
+cp "$SD/../../../../requirements.txt" "$TMP_SCRATCH/"
+cp "$SD/../../../../setup.py" "$TMP_SCRATCH/"
+cp -r "$SD/../../../../sheepdog" "$TMP_SCRATCH/sheepdog"
+
+# Bring up a blank docker image, with the kennel and pup.
+docker build -t $IMAGE_NAME .
+
+IS_INTERACTIVE=false
+
+while [ $# -ne 0 ]
+do
+    case "$1" in
+    --interactive)
+        IS_INTERACTIVE=true
+        ;;
+    *)
+        ;;
+    esac
+    shift
+done
+
+if [ "$IS_INTERACTIVE" == "true" ]
+then
+    docker run -it $IMAGE_NAME /bin/bash
+else
+    docker run $IMAGE_NAME /bin/bash -c "$DIR/run_sheepdog.sh && $DIR/assert_e2e_state.sh"
+fi


### PR DESCRIPTION
Fix #20

If a user manages their kennel through Git, and applies the same kennel
to multiple machines, the regularly scheduled cron run should pick up
the most recent changes. Set up the cron job to check if the git manages
the kennel, and if yes, run a `git pull origin master` and a `sheepdog
install` before the `sheepdog run` command.