### PR TITLE
Refactor cli to use `click` group

### DIFF
--- a/sheepdog/cli.py
+++ b/sheepdog/cli.py
@@ -6,55 +6,50 @@ from sheepdog.action.install import InstallAction
 from sheepdog.action.run import RunAction
 from sheepdog.app import Sheepdog
 from sheepdog.config import Config, KennelRunModes
-from sheepdog.exception import SheepdogCLIImproperArgumentsException
 
-ACTIONS = {
-    'install': InstallAction,
-    'run': RunAction
-}
 
-@click.command()
-@click.argument('action', type=click.Choice(ACTIONS.keys()))
-@click.option('--config-file', default='kennel.cfg')
-@click.option('--run-mode', type=click.Choice([KennelRunModes.NORMAL,
-                                               KennelRunModes.BOOTSTRAP,
-                                               KennelRunModes.CRON]))
-def cli(action, config_file, run_mode):
-    """CLI for sheepdog interactions.
+def _initialize_config(config_file, config_options=None):
+    config_options = config_options or {}
 
-    :param action: Which cli action we wish to take.
-    :type action: str
-    :param config_file: Path to kennel configuration. If not specified, use
-    `./kennel.cfg`
-    :type config_file: str
-    :param run_mode: The mode in which `sheepdog run` is occurring (i.e.
-    cron, bootstrap...`
-    :type run_mode: str
-    """
     with open(config_file, 'r') as config_file_open_for_reading:
         config_file_contents = config_file_open_for_reading.read()
-
-    config_options = {}
-
-    if run_mode is not None:
-        if action != 'run':
-            err_msg = 'Cannot specify `run_mode` if action is not `run`.'
-            raise SheepdogCLIImproperArgumentsException(err_msg)
-
-        config_options['kennel_run_mode'] = run_mode
 
     Config.initialize_config_singleton(
         config_file_contents=config_file_contents,
         config_options=config_options
     )
 
-    action = ACTIONS[action]()
 
-    sheepdog = Sheepdog(action)
-    sheepdog.run()
+@click.group()
+def cli():
+    pass
+
+
+@cli.command()
+@click.option('--config-file', default='kennel.cfg')
+def install(config_file):
+    _initialize_config(config_file)
+
+    install_action = InstallAction()
+    Sheepdog(install_action).run()
+
+
+@cli.command()
+@click.option('--run-mode', default=KennelRunModes.NORMAL,
+              type=click.Choice([KennelRunModes.NORMAL,
+                                 KennelRunModes.BOOTSTRAP,
+                                 KennelRunModes.CRON]))
+@click.option('--config-file', default='kennel.cfg')
+def run(run_mode, config_file):
+    config_options = {
+        'kennel_run_mode': run_mode
+    }
+
+    _initialize_config(config_file, config_options)
+
+    run_action = RunAction()
+    Sheepdog(run_action).run()
 
 
 def main():
-    """The entry point for running `sheepdog`."""
-    # pylint: disable=no-value-for-parameter
     cli()

--- a/sheepdog/exception.py
+++ b/sheepdog/exception.py
@@ -6,10 +6,6 @@ class SheepdogAnsibleDependenciesInstallException(SheepdogException):
     pass
 
 
-class SheepdogCLIImproperArgumentsException(SheepdogException):
-    pass
-
-
 class SheepdogConfigurationAlreadyInitializedException(SheepdogException):
     pass
 

--- a/sheepdog/pup.py
+++ b/sheepdog/pup.py
@@ -28,6 +28,7 @@ def _pup_types_to_classes():
         'git': GitPup
     }
 
+
 def _dependency_types_to_classes():
     return {
         'txt': PythonDependencies,

--- a/tests/unit/action/test_install.py
+++ b/tests/unit/action/test_install.py
@@ -1,7 +1,0 @@
-import unittest
-
-from sheepdog.action.install import InstallAction
-
-class TestInstall(unittest.TestCase):
-    def test_true(self):
-        self.assertTrue()

--- a/tests/unit/action/test_run.py
+++ b/tests/unit/action/test_run.py
@@ -1,5 +1,0 @@
-import unittest
-
-class RunTestCase(unittest.TestCase):
-    def test_true(self):
-        self.assertTrue(True)

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1,5 +1,0 @@
-import unittest
-
-class AppTestCase(unittest.TestCase):
-    def test_true(self):
-        self.assertTrue(True)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,5 +1,0 @@
-import unittest
-
-class CliTestCase(unittest.TestCase):
-    def test_true(self):
-        self.assertTrue(True)


### PR DESCRIPTION
Previously, we had only one `click` action, which we tried
to use to execute all CLI actions. This usage was hard to extend, and
not an idiomatic use of `click`.

Instead, we define a `cli` `click` group, and then a number of different
commands on the group. We do this in preparation for adding the `create`
cli command.