### PR TITLE
Execute integration tests in parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ python:
 services:
   - docker
 
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y parallel
+
 install:
   - pip install -r requirements.txt
   - python setup.py develop

--- a/tests/integration/tests/cron-bootstrap/assert_e2e_state.sh
+++ b/tests/integration/tests/cron-bootstrap/assert_e2e_state.sh
@@ -8,12 +8,29 @@
 
 set -e
 
+MAX_TRIES=120
+
 # First argument is file, second is pattern, third is the min number of occurrences
 # of pattern we expect in file.
 assert_e2e_state::check_occurrences_in_file() {
-    matches=$(grep -s "$2" "$1" | wc -l)
+    tries=0
+    success=false
 
-    if [ "$matches" -lt "$3" ]
+    while [ "$tries" -lt "$MAX_TRIES" ]
+    do
+        matches=$(grep -s "$2" "$1" | wc -l)
+
+        if [ "$matches" -lt "$3" ]
+        then
+            sleep 1
+            let "tries += 1"
+        else
+            success=true
+            break
+        fi
+    done
+
+    if [ "$success" = false ]
     then
         echo "Failed $1, $2, $3" >&2
         exit 1

--- a/tests/integration/tests/cron-bootstrap/run_sheepdog.sh
+++ b/tests/integration/tests/cron-bootstrap/run_sheepdog.sh
@@ -7,6 +7,4 @@ DIR=/test/kennels/kennel-cron-bootstrap-sample
 cd $DIR;\
 sheepdog install &&\
 sheepdog run --run-mode bootstrap &&\
-sheepdog run &&\
-echo 'Waiting 120 seconds for cron job to execute' &&\
-sleep 120
+sheepdog run

--- a/tests/integration/tests/update-kennel-before-cron/assert_e2e_state.sh
+++ b/tests/integration/tests/update-kennel-before-cron/assert_e2e_state.sh
@@ -8,12 +8,29 @@
 
 set -e
 
+MAX_TRIES=120
+
 # First argument is file, second is pattern, third is the min number of occurrences
 # of pattern we expect in file.
 assert_e2e_state::check_occurrences_in_file() {
-    matches=$(grep -s "$2" "$1" | wc -l)
+    tries=0
+    success=false
 
-    if [ "$matches" -lt "$3" ]
+    while [ "$tries" -lt "$MAX_TRIES" ]
+    do
+        matches=$(grep -s "$2" "$1" | wc -l)
+
+        if [ "$matches" -lt "$3" ]
+        then
+            sleep 1
+            let "tries += 1"
+        else
+            success=true
+            break
+        fi
+    done
+
+    if [ "$success" = false ]
     then
         echo "Failed $1, $2, $3" >&2
         exit 1

--- a/tests/integration/tests/update-kennel-before-cron/run_sheepdog.sh
+++ b/tests/integration/tests/update-kennel-before-cron/run_sheepdog.sh
@@ -7,6 +7,4 @@ DIR=/test/kennels/kennel-update-kennel-before-cron-sample
 cd $DIR;\
 sheepdog install &&\
 sheepdog run --run-mode bootstrap &&\
-sheepdog run &&\
-echo 'Waiting 120 seconds for cron job to execute' &&\
-sleep 120
+sheepdog run


### PR DESCRIPTION
Because all of our tests run in Docker containers, they should
be independent. Additionally, the integration tests spend a lot
of time blocking, waiting for a cron run. They are great candidates
for parallelization - this will hopefully reduce test time now,
and also allow better scaling.

Use Gnu parallel to automate running the scripts.