### PR TITLE
DRY running shell commands with subprocess

### DIFF
--- a/sheepdog/action/run.py
+++ b/sheepdog/action/run.py
@@ -1,10 +1,7 @@
 """Module for actions related to running a kennel."""
 
 from sheepdog.action import Action
-from sheepdog.exception import (SheepdogKennelRunException,
-                                SheepdogRunActionException)
 from sheepdog.kennel import Kennel
-
 
 
 class RunAction(Action):
@@ -17,7 +14,4 @@ class RunAction(Action):
         self._kennel = Kennel()
 
     def _execute(self):
-        try:
-            self._kennel.run()
-        except SheepdogKennelRunException as err:
-            raise SheepdogRunActionException(err.message)
+        self._kennel.run()

--- a/sheepdog/exception.py
+++ b/sheepdog/exception.py
@@ -2,10 +2,6 @@ class SheepdogException(Exception):
     pass
 
 
-class SheepdogAnsibleDependenciesInstallException(SheepdogException):
-    pass
-
-
 class SheepdogConfigurationAlreadyInitializedException(SheepdogException):
     pass
 
@@ -14,25 +10,9 @@ class SheepdogConfigurationNotInitializedException(SheepdogException):
     pass
 
 
-class SheepdogGalaxyPupInstallException(SheepdogException):
-    pass
-
-
-class SheepdogGitPupInstallException(SheepdogException):
-    pass
-
-
 class SheepdogInvalidPupTypeException(SheepdogException):
     pass
 
 
-class SheepdogKennelRunException(SheepdogException):
-    pass
-
-
-class SheepdogPythonDependenciesInstallException(SheepdogException):
-    pass
-
-
-class SheepdogRunActionException(SheepdogException):
+class SheepdogShellRunnerException(SheepdogException):
     pass

--- a/sheepdog/utils.py
+++ b/sheepdog/utils.py
@@ -1,0 +1,40 @@
+import os
+import subprocess
+
+from sheepdog.exception import SheepdogShellRunnerException
+
+
+class ShellRunner(object):
+    """A wrapper around the `subprocess.check_call` command, to DRY the
+    transformations necessary to run a shell command.
+
+    :param cmd_as_list: The command for the `ShellRunner` to execute.
+    :type cmd_as_list: list
+    :raises: SheepdogShellRunnerException
+    """
+    def __init__(self, cmd_as_list):
+        self._cmd_as_str = ' '.join(cmd_as_list)
+
+    def run(self, env_additions=None):
+        """Execute the command wrapped by `ShellRunner`.
+
+        :param env_additions: Optional method for specifying additional
+        environment variables for the shell in the subprocess in which the
+        command will execute.
+        :type env_additions: dict
+        """
+        env_additions = env_additions or {}
+
+        shell_env = os.environ.copy()
+        shell_env.update(env_additions)
+
+        try:
+            subprocess.check_call(
+                self._cmd_as_str,
+                shell=True,
+                env=shell_env
+            )
+        except subprocess.CalledProcessError as err:
+            raise SheepdogShellRunnerException(
+                '{} failed: {}'.format(self._cmd_as_str, err.message)
+            )

--- a/tests/unit/test_kennel.py
+++ b/tests/unit/test_kennel.py
@@ -25,6 +25,8 @@ class KennelTestCase(unittest.TestCase):
         self.assertEqual(os.listdir(mock_kennel_path), [])
         self.assertTrue(os.path.isdir(mock_kennel_path))
 
+    # @TODO(mattjmcnaughton) Consider using dependency injection for
+    # `ShellRunner` instead of patching `subprocess.check_call`.
     @mock.patch('subprocess.check_call')
     def test_kennel_run(self, mock_check_call):
         """Test running the kennel. We only test that it passes the correct


### PR DESCRIPTION
Refactor to DRY calling shell commands with `subprocess`. We wrote
the same code in multiple places, so extract it into a utility class.

Additionally, reduce the number of custom errors we define. Previously,
each operation would catch the error types of the suboperations it was
running, and then return a custom error message. I have a feeling this
indirection will make the stack dumps confusing. Now, only low level
commands with an actual risk of failing raise exceptions, and the other
system components let these errors bubble up.